### PR TITLE
add setState for selectedDate in onDaySelected

### DIFF
--- a/src/DatePicker.js
+++ b/src/DatePicker.js
@@ -162,6 +162,7 @@ export default class DatePicker extends React.Component<Props, State> {
     }
     selectedDate.setHours(hours)
     selectedDate.setMinutes(minutes)
+    this.setState({ selectedDate })
     this.onDateSelected(selectedDate)
   }
 


### PR DESCRIPTION
Currently the date picker does not update the state of the selected date. So when a user changes the date, and then changes the hours, minutes or AM/PM, the selected date is the initDate. Adding setState for the selectedDate in the onSelectedDate function updates the state so that when the other functions are called, ex onHourSelected, the selectedDate that is gets from state is the last date the user selected.